### PR TITLE
Activate the virtualenv only when the activation script exists

### DIFF
--- a/.env
+++ b/.env
@@ -1,2 +1,4 @@
 _envdir=$(dirname "$1")
-source $_envdir/flywheel_env/bin/activate
+if [ -f "$_envdir/flywheel_env/bin/activate" ]; then
+  source $_envdir/flywheel_env/bin/activate
+fi


### PR DESCRIPTION
I use autoenv and virtualenv, but my virtualenv setup is a bit different than yours. I created a virtualenv for flywheel but it's in `$VIRTUALENV_HOME`, not `./flywheel_env`. Unfortunately, every time I `cd` inside the Flywheel source code, I get an error because `./flywheel_env/bin/activate` doesn't exist.

This change prevents users from getting that error if they don't have the same setup as yours.
