### PR TITLE
Allow users to specify the namespace separator

### DIFF
--- a/flywheel/model_meta.py
+++ b/flywheel/model_meta.py
@@ -332,15 +332,19 @@ class ModelMetadata(object):
         """ Getter for abstract """
         return self._abstract
 
-    def ddb_tablename(self, namespace=()):
+    def ddb_tablename(self, namespace=(), namespace_separator='-'):
         """
         The name of the DynamoDB table
 
         Parameters
         ----------
         namespace : list or str, optional
-            String prefix or list of component parts of a prefix for the table
-            name.  The prefix will be this string or strings (joined by '-').
+            String prefix or list of component parts of a prefix for models. All
+            table names will be prefixed by this string or strings (joined by the
+            separator below).
+        namespace_separator: str, optional
+            String to use when joining the namespace to the table name. Default is
+            '-'.
 
         """
         if isinstance(namespace, six.string_types):
@@ -349,7 +353,7 @@ class ModelMetadata(object):
             namespace = tuple(namespace)
         if self.abstract:
             return None
-        return '-'.join(namespace + (self.name,))
+        return namespace_separator.join(namespace + (self.name,))
 
     def validate_model(self):
         """ Perform validation checks on the model declaration """
@@ -386,7 +390,8 @@ class ModelMetadata(object):
                                               "itself" % (name, field.name))
 
     def create_dynamo_schema(self, connection, tablenames=None, test=False,
-                             wait=False, throughput=None, namespace=()):
+                             wait=False, throughput=None, namespace=(),
+                             namespace_separator='-'):
         """
         Create all Dynamo tables for this model
 
@@ -407,6 +412,8 @@ class ModelMetadata(object):
             value.
         namespace : tuple, optional
             The namespace of the table
+        namespace_separator : str, optional
+            The string to use when joining the parts of the table's namespace
 
         Returns
         -------
@@ -418,7 +425,7 @@ class ModelMetadata(object):
             return None
         if tablenames is None:
             tablenames = set(connection.list_tables())
-        tablename = self.ddb_tablename(namespace)
+        tablename = self.ddb_tablename(namespace, namespace_separator)
         if tablename in tablenames:
             return None
         elif test:
@@ -463,7 +470,7 @@ class ModelMetadata(object):
         return tablename
 
     def delete_dynamo_schema(self, connection, tablenames=None, test=False,
-                             wait=False, namespace=()):
+                             wait=False, namespace=(), namespace_separator='-'):
         """
         Drop all Dynamo tables for this model
 
@@ -479,6 +486,8 @@ class ModelMetadata(object):
             If True, block until table has been deleted (default False)
         namespace : tuple, optional
             The namespace of the table
+        namespace_separator : str, optional
+            The string to use when joining the parts of the table's namespace
 
         Returns
         -------
@@ -491,7 +500,7 @@ class ModelMetadata(object):
         if tablenames is None:
             tablenames = set(connection.list_tables())
 
-        tablename = self.ddb_tablename(namespace)
+        tablename = self.ddb_tablename(namespace, namespace_separator)
         if tablename in tablenames:
             if not test:
                 connection.delete_table(tablename)

--- a/flywheel/query.py
+++ b/flywheel/query.py
@@ -32,7 +32,7 @@ class Query(object):
     @property
     def tablename(self):
         """ Shortcut to access dynamo table name """
-        return self.model.meta_.ddb_tablename(self.engine.namespace)
+        return self.model.meta_.ddb_tablename(self.engine.namespace, self.engine.namespace_separator)
 
     def gen(self, desc=False, consistent=False, attributes=None,
             filter_or=False):

--- a/flywheel/tests.py
+++ b/flywheel/tests.py
@@ -18,7 +18,8 @@ class DynamoSystemTest(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
         super(DynamoSystemTest, cls).setUpClass()
-        cls.engine = Engine(cls.dynamo, ['test'])
+        cls.engine = Engine(cls.dynamo, namespace=['test'],
+                            namespace_separator='X')
         cls.engine.register(*cls.models)
         cls.engine.create_schema()
 

--- a/tests/test_fields.py
+++ b/tests/test_fields.py
@@ -330,7 +330,8 @@ class TestFields(DynamoSystemTest):
         """ Default field values are saved to dynamo """
         w = Widget(string2='abc')
         self.engine.sync(w)
-        tablename = Widget.meta_.ddb_tablename(self.engine.namespace)
+        tablename = Widget.meta_.ddb_tablename(
+            self.engine.namespace, self.engine.namespace_separator)
         result = six.next(self.dynamo.scan(tablename))
         self.assertEquals(result, {
             'string': w.string,
@@ -373,7 +374,8 @@ class TestFields(DynamoSystemTest):
         w = Widget(string='a', foobar=5)
         self.engine.sync(w)
 
-        tablename = Widget.meta_.ddb_tablename(self.engine.namespace)
+        tablename = Widget.meta_.ddb_tablename(
+            self.engine.namespace, self.engine.namespace_separator)
         result = six.next(self.dynamo.scan(tablename))
         self.assertEquals(result['foobar'], 5)
         stored_widget = self.engine.scan(Widget).all()[0]
@@ -384,7 +386,8 @@ class TestFields(DynamoSystemTest):
         w = Widget(string='a', foobar='hi')
         self.engine.sync(w)
 
-        tablename = Widget.meta_.ddb_tablename(self.engine.namespace)
+        tablename = Widget.meta_.ddb_tablename(
+            self.engine.namespace, self.engine.namespace_separator)
         result = six.next(self.dynamo.scan(tablename))
         self.assertEquals(result['foobar'], json.dumps('hi'))
         stored_widget = self.engine.scan(Widget).all()[0]
@@ -396,7 +399,8 @@ class TestFields(DynamoSystemTest):
         w = Widget(string='a', foobar=foobar)
         self.engine.sync(w)
 
-        tablename = Widget.meta_.ddb_tablename(self.engine.namespace)
+        tablename = Widget.meta_.ddb_tablename(
+            self.engine.namespace, self.engine.namespace_separator)
         result = six.next(self.dynamo.scan(tablename))
         self.assertEquals(result['foobar'], foobar)
         stored_widget = self.engine.scan(Widget).all()[0]
@@ -408,7 +412,8 @@ class TestFields(DynamoSystemTest):
         w = Widget(string='a', foobar=foobar)
         self.engine.save(w)
 
-        tablename = Widget.meta_.ddb_tablename(self.engine.namespace)
+        tablename = Widget.meta_.ddb_tablename(
+            self.engine.namespace, self.engine.namespace_separator)
         result = six.next(self.dynamo.scan(tablename))
         self.assertEquals(result['foobar'], json.dumps(foobar))
         stored_widget = self.engine.scan(Widget).all()[0]

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -82,7 +82,8 @@ class TestComposite(DynamoSystemTest):
         """ Composite fields stored properly in dynamodb """
         w = Widget('a', 'b', 1)
         self.engine.save(w)
-        tablename = Widget.meta_.ddb_tablename(self.engine.namespace)
+        tablename = Widget.meta_.ddb_tablename(
+            self.engine.namespace, self.engine.namespace_separator)
         item = six.next(self.dynamo.scan(tablename))
         self.assertEquals(item['c_range'], w.c_range)
         self.assertEquals(item['c_index'], w.c_index)
@@ -103,7 +104,8 @@ class TestComposite(DynamoSystemTest):
         self.engine.save(w)
         w.text = 'foobar'
         w.sync()
-        tablename = w.meta_.ddb_tablename(self.engine.namespace)
+        tablename = w.meta_.ddb_tablename(
+            self.engine.namespace, self.engine.namespace_separator)
         results = self.dynamo.batch_get(tablename,
                                         [{w.meta_.hash_key.name: w.hk_}])
         results = list(results)
@@ -122,7 +124,8 @@ class TestComposite(DynamoSystemTest):
         self.engine.save(w)
         w.likes += 2
         w.sync()
-        tablename = w.meta_.ddb_tablename(self.engine.namespace)
+        tablename = w.meta_.ddb_tablename(
+            self.engine.namespace, self.engine.namespace_separator)
         results = self.dynamo.batch_get(tablename,
                                         [{w.meta_.hash_key.name: w.hk_}])
         results = list(results)
@@ -168,7 +171,8 @@ class TestModelMutation(DynamoSystemTest):
         """ Saving item puts it in the database """
         a = Article()
         self.engine.save(a)
-        tablename = a.meta_.ddb_tablename(self.engine.namespace)
+        tablename = a.meta_.ddb_tablename(
+            self.engine.namespace, self.engine.namespace_separator)
         result = six.next(self.dynamo.scan(tablename))
         self.assertEquals(result['title'], a.title)
         self.assertIsNone(result.get('text'))
@@ -187,7 +191,8 @@ class TestModelMutation(DynamoSystemTest):
         self.engine.save(a)
         a2 = Article(text='obviously')
         self.engine.save(a2, overwrite=True)
-        tablename = a.meta_.ddb_tablename(self.engine.namespace)
+        tablename = a.meta_.ddb_tablename(
+            self.engine.namespace, self.engine.namespace_separator)
         result = six.next(self.dynamo.scan(tablename))
         self.assertEquals(result['title'], a2.title)
         self.assertEquals(result['text'], a2.text)
@@ -198,7 +203,8 @@ class TestModelMutation(DynamoSystemTest):
         self.engine.save(a)
         a2 = Article(beta='ih')
         self.engine.save(a2, overwrite=True)
-        tablename = a.meta_.ddb_tablename(self.engine.namespace)
+        tablename = a.meta_.ddb_tablename(
+            self.engine.namespace, self.engine.namespace_separator)
         result = six.next(self.dynamo.scan(tablename))
         self.assertEquals(result['title'], a2.title)
         self.assertEquals(json.loads(result['beta']), a2.beta)
@@ -322,7 +328,8 @@ class TestModelMutation(DynamoSystemTest):
         """ Sync creates item even if only primary key is set """
         a = Article()
         self.engine.sync(a)
-        tablename = a.meta_.ddb_tablename(self.engine.namespace)
+        tablename = a.meta_.ddb_tablename(
+            self.engine.namespace, self.engine.namespace_separator)
         results = list(self.dynamo.scan(tablename))
         self.assertEquals(len(results), 1)
         result = dict(results[0])
@@ -511,7 +518,8 @@ class TestModelMutation(DynamoSystemTest):
         p.incr_(likes=4)
         p.sync()
 
-        tablename = p.meta_.ddb_tablename(self.engine.namespace)
+        tablename = p.meta_.ddb_tablename(
+            self.engine.namespace, self.engine.namespace_separator)
         result = six.next(self.dynamo.scan(tablename))
         self.assertEquals(result['ts'], 0)
         self.assertEquals(result['likes'], 4)
@@ -524,7 +532,8 @@ class TestModelMutation(DynamoSystemTest):
         p.incr_(likes=4)
         p.sync(raise_on_conflict=True)
 
-        tablename = p.meta_.ddb_tablename(self.engine.namespace)
+        tablename = p.meta_.ddb_tablename(
+            self.engine.namespace, self.engine.namespace_separator)
         result = six.next(self.dynamo.scan(tablename))
         self.assertEquals(result['ts'], 0)
         self.assertEquals(result['likes'], 4)
@@ -559,7 +568,8 @@ class TestModelMutation(DynamoSystemTest):
         p.foobar = None
         p.sync()
 
-        tablename = p.meta_.ddb_tablename(self.engine.namespace)
+        tablename = p.meta_.ddb_tablename(
+            self.engine.namespace, self.engine.namespace_separator)
         result = six.next(self.dynamo.scan(tablename))
         self.assertFalse('foobar' in result)
 
@@ -705,7 +715,8 @@ class TestCreate(DynamoSystemTest):
 
     def _get_index(self, name):
         """ Get a specific index from the Store table """
-        tablename = Store.meta_.ddb_tablename(self.engine.namespace)
+        tablename = Store.meta_.ddb_tablename(
+            self.engine.namespace, self.engine.namespace_separator)
         desc = self.dynamo.describe_table(tablename)
         for index in desc.indexes + desc.global_indexes:
             if index.name == name:

--- a/tests/test_queries.py
+++ b/tests/test_queries.py
@@ -300,7 +300,8 @@ class TestQueries(DynamoSystemTest):
     def test_double_limit(self):
         """ Calling limit twice on the same query raises error """
         with self.assertRaises(ValueError):
-            self.engine.query(User).filter(name='Adam').limit(10).limit(5).all()
+            self.engine.query(User).filter(
+                name='Adam').limit(10).limit(5).all()
 
     def test_double_index(self):
         """ Calling index twice on the same query raises error """


### PR DESCRIPTION
My company [Runscope](http://www.runscope.com) is probably going to use Flywheel pretty heavily as we expand our use of DynamoDB. We're already familiar with the basic ORM approach from our experience with SQLAlchemy. I personally built one project on top of Flywheel so far, and I've been pretty happy with it.

Anyway, we use table namespaces similar to what Flywheel supports, but we've already standardized on "." as the separator between elements. For example, our table names are `prod.atlas.hosts` and `test.scorekeeper.requests`. This commit allows Flywheel's namespace feature to work for us too.

This is my first pull request to the Flywheel project, so let me know if there are any stylistic norms that I should follow.
