### PR TITLE
Move pep8 configuration to setup.cfg

### DIFF
--- a/.pep8.ini
+++ b/.pep8.ini
@@ -1,3 +1,0 @@
-[pep8]
-max-line-length=80
-ignore=E501,E24

--- a/run_autopep8.sh
+++ b/run_autopep8.sh
@@ -1,5 +1,5 @@
 #!/bin/bash -e
-declare -r CONF=".pep8.ini"
+declare -r CONF="setup.cfg"
 declare -r ARGS=(ignore select max-line-length)
 declare -r HELP="usage: $0 [all]
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -5,3 +5,7 @@ dynamo-port=8001
 
 [wheel]
 universal = 1
+
+[pep8]
+max-line-length=80
+ignore=E501,E24

--- a/tox.ini
+++ b/tox.ini
@@ -24,4 +24,4 @@ deps =
 commands =
     coverage run --source=flywheel --branch setup.py nosetests
     pylint --rcfile=.pylintrc flywheel tests
-    pep8 --config=.pep8.ini flywheel tests
+    pep8 flywheel tests


### PR DESCRIPTION
pep8 documentation says that .pep8 files are deprecated, but it will
automatically read settings from a [pep8] section in setup.cfg. I've
moved the .pep8.ini content to setup.cfg, which means that the pep8
command won't need the --config parameter anymore.

We run Flywheel tests on our Jenkins server at Runscope, and we made this
change to make Flywheel's packaging a little bit more compatible with our
Jenkins setup.
