### PR TITLE
Use attribute_not_exists() condition to avoid overwrite on save.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,6 +38,7 @@ flywheel_env
 .ropeproject
 _localhost.db
 _local.db
+/venv/
 
 # docs
 _build

--- a/flywheel/engine.py
+++ b/flywheel/engine.py
@@ -516,11 +516,12 @@ class Engine(object):
                         item.post_save_()
             else:
                 for item in items:
-                    expected = dict(((k + '__null', True) for k in
-                                     item.pk_dict_))
+                    condition = " AND ".join([
+                        "attribute_not_exists({})".format(k)
+                        for k in item.pk_dict_])
                     item.pre_save_(self)
-                    self.dynamo.put_item(tablename, item.ddb_dump_(),
-                                         **expected)
+                    self.dynamo.put_item2(tablename, item.ddb_dump_(),
+                                          condition=condition)
                     item.post_save_()
 
     def refresh(self, items, consistent=False):


### PR DESCRIPTION
This replaces the older primary-key-not-null pattern that we
implemented using the deprecated expression syntax. It is now the
recommended way to avoid overwriting an existing item in put - see
https://boto3.readthedocs.io/en/latest/reference/services/dynamodb.html#DynamoDB.Client.put_item

A bonus is that the `moto` library (which is often used as an in-memory
implementation for testing) implements the attribute_not_exists()
semantics, whereas it does not implement is-null tests for a missing
item.