### PR TITLE
Don’t ddb_load primary key in refresh()

### DIFF
--- a/flywheel/engine.py
+++ b/flywheel/engine.py
@@ -553,7 +553,7 @@ class Engine(object):
                                             consistent=consistent)
             meta = items[0].meta_
             for result in results:
-                pkey = meta.pk_tuple(None, result, ddb_load=True)
+                pkey = meta.pk_tuple(None, result)
                 item = model_map[tablename].get(pkey)
                 if item is None:
                     LOG.error("Refresh error: Cannot match primary key %r to "


### PR DESCRIPTION
The values of model_map[tablename] are keyed by Model#pk_tuple_.
Model#pk_tuple_ does not ddb_load its values, so pkey must also not be
ddb_loaded, to avoid spurious misses when retrieving from
model_mal[tablename] on line 557.

This fixes Model#refresh() when using custom-Typed primary keys.