### PR TITLE
docs: Fix a few typos

### DIFF
--- a/doc/topics/models/composite_fields.rst
+++ b/doc/topics/models/composite_fields.rst
@@ -5,7 +5,7 @@ Composite Fields
 Composite fields allow you to create fields that are combinations of multiple
 other fields. Suppose you're creating a table where you plan to store a
 collection of social media items (tweets, facebook posts, instagram pics, etc).
-If you make the hash key the id of the item, there is the remote possiblity
+If you make the hash key the id of the item, there is the remote possibility
 that a tweet id will collide with a facebook id. Here is the solution:
 
 .. code-block:: python

--- a/flywheel/engine.py
+++ b/flywheel/engine.py
@@ -593,7 +593,7 @@ class Engine(object):
         ------
         exc : :class:`dynamo3.CheckFailed`
             If raise_on_conflict=True and the data in dynamo fails the
-            contraint checks.
+            constraint checks.
 
         """
         if raise_on_conflict is None:

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ from setuptools import find_packages, setup
 
 HERE = os.path.abspath(os.path.dirname(__file__))
 README = open(os.path.join(HERE, 'README.rst')).read()
-# Remove syntax highighting for pypi
+# Remove syntax highlighting for pypi
 README = re.sub(r'.. sourcecode.*', '::', README)
 CHANGES = open(os.path.join(HERE, 'CHANGES.rst')).read()
 # Remove custom RST extensions for pypi

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -255,7 +255,7 @@ class TestModelMutation(DynamoSystemTest):
             captured_updates = []
 
             def update_item(_, __, updates, *___, **____):
-                """ Mock update_item and capture the passed updateds """
+                """ Mock update_item and capture the passed updates """
                 captured_updates.extend(updates)
                 return {}
             dynamo.update_item.side_effect = update_item


### PR DESCRIPTION
There are small typos in:
- doc/topics/models/composite_fields.rst
- flywheel/engine.py
- setup.py
- tests/test_models.py

Fixes:
- Should read `updates` rather than `updateds`.
- Should read `possibility` rather than `possiblity`.
- Should read `highlighting` rather than `highighting`.
- Should read `constraint` rather than `contraint`.



Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md